### PR TITLE
Validity Field Fix

### DIFF
--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -17,6 +17,7 @@ const theTrackedThing: Tracker = {
 	acceleration: zeroVector,
 	target: zeroVector,
 	status: true,
+	validity: 1,
 }
 
 const trackers = Array(10).fill(theTrackedThing).map((t, idx) => ({

--- a/src/encodeDataPacket.ts
+++ b/src/encodeDataPacket.ts
@@ -60,7 +60,7 @@ const trackerDataChunks = (tracker: Tracker): Buffer[] => {
 		vecToChunk(tracker.position, 0x0000),
 		vecToChunk(tracker.speed, 0x0001),
 		vecToChunk(tracker.orientation, 0x0002),
-		wrapChunk(Buffer.from([1]), 0x0003, false),
+		floatToChunk(tracker.validity, 0x0003),
 		vecToChunk(tracker.acceleration, 0x0004),
 		vecToChunk(tracker.target, 0x0005),
 	]
@@ -71,6 +71,16 @@ const vecToChunk = (vec: Vector3, chunkId: number): Buffer => {
 	buffer.writeFloatLE(vec.x, 0)
 	buffer.writeFloatLE(vec.y, 4)
 	buffer.writeFloatLE(vec.z, 8)
+	return wrapChunk(
+		buffer,
+		chunkId,
+		false,
+	)
+}
+
+const floatToChunk = (value: number, chunkId: number): Buffer => {
+	const buffer = Buffer.allocUnsafe(4)
+	buffer.writeFloatLE(value, 0)
 	return wrapChunk(
 		buffer,
 		chunkId,

--- a/src/encodeDataPacket.ts
+++ b/src/encodeDataPacket.ts
@@ -67,7 +67,7 @@ const trackerDataChunks = (tracker: Tracker): Buffer[] => {
 }
 
 const vecToChunk = (vec: Vector3, chunkId: number): Buffer => {
-	const buffer = Buffer.alloc(12)
+	const buffer = Buffer.allocUnsafe(12)
 	buffer.writeFloatLE(vec.x, 0)
 	buffer.writeFloatLE(vec.y, 4)
 	buffer.writeFloatLE(vec.z, 8)

--- a/src/sendUdp.ts
+++ b/src/sendUdp.ts
@@ -32,7 +32,7 @@ const theTrackedThing: Tracker = {
 	acceleration: zeroVector,
 	target: zeroVector,
 	status: true,
-
+	validity: 1,
 }
 
 const names = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface Tracker {
 	orientation: Vector3 // rotation is in RADIANS!
 	target: Vector3
 	status: boolean
+	validity: number
 }
 
 export interface Vector3 {


### PR DESCRIPTION
This pull request tries to fix the size of the validity field. It should be a 32 bit float. The wrong size lead to TouchDesigner crashing and GrandMA on PC wasn't able to decode values.

This fix also contains a new property on the Tracker type, which can be used to set the validity individually.